### PR TITLE
On init do not die

### DIFF
--- a/HobknobClientNet.Tests/Scenarios/CacheUpdates.cs
+++ b/HobknobClientNet.Tests/Scenarios/CacheUpdates.cs
@@ -61,7 +61,7 @@ namespace HobknobClientNet.Tests.Scenarios
             Given_a_toggle(ApplicationName, "existingChange", "true");
             Given_a_toggle(ApplicationName, "existingRemoved", "true");
 
-            var hobknobClient = Create_hobknob_client();
+            var hobknobClient = Create_hobknob_client(Create_exception_throwing_error_handler());
 
             Given_a_toggle(ApplicationName, "newToggle", "true");
             Given_a_toggle(ApplicationName, "existingChange", "false");

--- a/HobknobClientNet.Tests/Scenarios/CacheUpdates.cs
+++ b/HobknobClientNet.Tests/Scenarios/CacheUpdates.cs
@@ -22,7 +22,7 @@ namespace HobknobClientNet.Tests.Scenarios
         }
 
         [TearDown]
-        public void TearDown()
+        public new void TearDown()
         {
             EtcdClient.DeleteDir(new Uri("v1/toggles/cacheUpdateTest/", UriKind.Relative));
         }

--- a/HobknobClientNet.Tests/Scenarios/GetOrDefault_SimpleFeature.cs
+++ b/HobknobClientNet.Tests/Scenarios/GetOrDefault_SimpleFeature.cs
@@ -30,6 +30,13 @@ namespace HobknobClientNet.Tests.Scenarios
         }
 
         [Test]
+        public void Default_is_used_when_host_cannot_be_reached()
+        {
+            When_I_get_with_default_and_host("bad_host","feature3", true, out _toggleValue);
+            Assert.That(_toggleValue, Is.True);
+        }
+
+        [Test]
         public void Applications_do_not_clash()
         {
             Given_a_toggle("app1", "feature1", "true");

--- a/HobknobClientNet.Tests/Scenarios/Initialisation.cs
+++ b/HobknobClientNet.Tests/Scenarios/Initialisation.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 
 namespace HobknobClientNet.Tests.Scenarios
 {
@@ -16,7 +17,7 @@ namespace HobknobClientNet.Tests.Scenarios
         public void Initialises_happy_path()
         {
             Given_a_toggle("app1", "feature1", "true");
-            HobknobClient = Create_hobknob_client();
+            HobknobClient = Create_hobknob_client(Create_exception_throwing_error_handler());
         }
 
         [Test]
@@ -25,22 +26,32 @@ namespace HobknobClientNet.Tests.Scenarios
             Given_a_toggle("app1", "feature1", "true");
             Given_a_toggle_is_removed("app1", "feature1");
 
-            HobknobClient = Create_hobknob_client();
+            HobknobClient = Create_hobknob_client(Create_exception_throwing_error_handler());
         }
 
         [Test]
         public void Initialises_ok_if_application_does_not_exist()
         {
             Set_application_name("app1234");
-            HobknobClient = Create_hobknob_client();
+            HobknobClient = Create_hobknob_client(Create_exception_throwing_error_handler());
         }
 
         [Test]
-        public void Throws_exception_on_network_error()
+        public void Throws_exception_if_error_handler_is_null()
+        {            
+            Assert.That(() => HobknobClient = Create_hobknob_client(null),
+                Throws.Exception.Message.Contains("cacheUpdateFailed"));
+        }
+
+        [Test]
+        public void Initialises_ok_on_network_error_and_error_handler_gets_called()
         {
-            
-            Assert.That(() => HobknobClient = Create_hobknob_client("bad_host"),
-                Throws.Exception.Message.Contains("host"));
+            var errorsCounter = 0;            
+            HobknobClient = Create_hobknob_client(delegate
+            {
+                errorsCounter++;
+            }, "bad_host");
+            Assert.That(errorsCounter, Is.EqualTo(1));
         }
     }
 }

--- a/HobknobClientNet.Tests/Scenarios/Initialisation.cs
+++ b/HobknobClientNet.Tests/Scenarios/Initialisation.cs
@@ -47,10 +47,7 @@ namespace HobknobClientNet.Tests.Scenarios
         public void Initialises_ok_on_network_error_and_error_handler_gets_called()
         {
             var errorsCounter = 0;            
-            HobknobClient = Create_hobknob_client(delegate
-            {
-                errorsCounter++;
-            }, "bad_host");
+            HobknobClient = Create_hobknob_client((sender, eventArgs) => { errorsCounter++; }, "bad_host");
             Assert.That(errorsCounter, Is.EqualTo(1));
         }
     }

--- a/HobknobClientNet.Tests/Scenarios/TestBase.cs
+++ b/HobknobClientNet.Tests/Scenarios/TestBase.cs
@@ -67,15 +67,22 @@ namespace HobknobClientNet.Tests.Scenarios
 
         protected void When_I_get_with_default(string featureName, bool defaultValue, out bool? value)
         {
-            When_I_get_with_default(featureName, null, defaultValue, out value);
+            When_I_get_with_default(EtcdHost, featureName, null, defaultValue, out value);
         }
 
-        protected void When_I_get_with_default(string featureName, string toggleName, bool defaultValue,  out bool? value)
+        protected void When_I_get_with_default_and_host(string etcdHost, string featureName, bool defaultValue, out bool? value)
         {
-            HobknobClient = new HobknobClientFactory().Create(EtcdHost, EtcdPort, _applicationName, TimeSpan.FromSeconds(1), delegate (object o, CacheUpdateFailedArgs args)
-            {
-                throw args.Exception;
-            });
+            When_I_get_with_default(etcdHost, featureName, null, defaultValue, out value);
+        }
+
+        protected void When_I_get_with_default(string featureName, string toggleName, bool defaultValue, out bool? value)
+        {
+            When_I_get_with_default(EtcdHost, featureName, toggleName, defaultValue, out value);
+        }
+
+        protected void When_I_get_with_default(string etcdHost, string featureName, string toggleName, bool defaultValue, out bool? value)
+        {
+            HobknobClient = new HobknobClientFactory().Create(etcdHost, EtcdPort, _applicationName, TimeSpan.FromSeconds(1), delegate {});
             value = HobknobClient.GetOrDefault(featureName, toggleName, defaultValue);
         }
 

--- a/HobknobClientNet.Tests/Scenarios/TestBase.cs
+++ b/HobknobClientNet.Tests/Scenarios/TestBase.cs
@@ -82,7 +82,7 @@ namespace HobknobClientNet.Tests.Scenarios
 
         protected void When_I_get_with_default(string etcdHost, string featureName, string toggleName, bool defaultValue, out bool? value)
         {
-            HobknobClient = new HobknobClientFactory().Create(etcdHost, EtcdPort, _applicationName, TimeSpan.FromSeconds(1), delegate {});
+            HobknobClient = new HobknobClientFactory().Create(etcdHost, EtcdPort, _applicationName, TimeSpan.FromSeconds(1), (o, args) => {});
             value = HobknobClient.GetOrDefault(featureName, toggleName, defaultValue);
         }
 
@@ -99,10 +99,7 @@ namespace HobknobClientNet.Tests.Scenarios
 
         protected EventHandler<CacheUpdateFailedArgs> Create_exception_throwing_error_handler()
         {
-            return delegate(object o, CacheUpdateFailedArgs args)
-            {
-                throw args.Exception;
-            };
+            return (o, args) => { throw args.Exception; };
         }
     }
 }

--- a/HobknobClientNet/FeatureToggleCache.cs
+++ b/HobknobClientNet/FeatureToggleCache.cs
@@ -28,11 +28,7 @@ namespace HobknobClientNet
 
         public void Initialize()
         {
-            Exception exception;
-            if (!UpdateCache(out exception))
-            {
-                throw exception;
-            }
+            UpdateCache();
             _timer = new Timer(UpdateCacheTick, null, _updateInterval, _updateInterval);
         }
 
@@ -44,7 +40,7 @@ namespace HobknobClientNet
             return _cache.TryGetValue(featureToggleKey, out value) ? value : (bool?)null;
         }
 
-        private bool UpdateCache(out Exception exception)
+        private bool UpdateCache()
         {
             Dictionary<string, bool> featureToggles;
             try
@@ -53,32 +49,19 @@ namespace HobknobClientNet
             }
             catch (Exception ex)
             {
-                if (CacheUpdateFailed != null)
-                {
-                    CacheUpdateFailed(this, new CacheUpdateFailedArgs(ex));
-                }
-
-                exception = ex;
+                CacheUpdateFailed?.Invoke(this, new CacheUpdateFailedArgs(ex));
                 return false;
             }
 
             var updates = GetUpdates(_cache, featureToggles);
-
             _cache = featureToggles;
-
-            if (CacheUpdated != null)
-            {
-                CacheUpdated(this, new CacheUpdatedArgs(updates));
-            }
-
-            exception = null;
+            CacheUpdated?.Invoke(this, new CacheUpdatedArgs(updates));
             return true;
         }
 
         private void UpdateCacheTick(object _)
         {
-            Exception ignore;
-            UpdateCache(out ignore);
+            UpdateCache();
         }
 
         private static IEnumerable<CacheUpdate> GetUpdates(Dictionary<string, bool> existingToggles, Dictionary<string, bool> newToggles)

--- a/HobknobClientNet/FeatureToggleCache.cs
+++ b/HobknobClientNet/FeatureToggleCache.cs
@@ -49,13 +49,15 @@ namespace HobknobClientNet
             }
             catch (Exception ex)
             {
-                CacheUpdateFailed?.Invoke(this, new CacheUpdateFailedArgs(ex));
+                if (CacheUpdateFailed != null)
+                    CacheUpdateFailed.Invoke(this, new CacheUpdateFailedArgs(ex));
                 return false;
             }
 
             var updates = GetUpdates(_cache, featureToggles);
             _cache = featureToggles;
-            CacheUpdated?.Invoke(this, new CacheUpdatedArgs(updates));
+            if (CacheUpdated != null)
+                CacheUpdated.Invoke(this, new CacheUpdatedArgs(updates));
             return true;
         }
 

--- a/HobknobClientNet/FeatureToggleCache.cs
+++ b/HobknobClientNet/FeatureToggleCache.cs
@@ -37,7 +37,7 @@ namespace HobknobClientNet
             var toggleSuffix = toggleName != null ? "/" + toggleName : string.Empty;
             var featureToggleKey = string.Format("/v1/toggles/{0}/{1}{2}", applicationName, featureName, toggleSuffix);
             bool value;
-            return _cache.TryGetValue(featureToggleKey, out value) ? value : (bool?)null;
+            return _cache != null && _cache.TryGetValue(featureToggleKey, out value) ? value : (bool?)null;
         }
 
         private bool UpdateCache()

--- a/HobknobClientNet/FeatureToggleCache.cs
+++ b/HobknobClientNet/FeatureToggleCache.cs
@@ -51,7 +51,7 @@ namespace HobknobClientNet
             {
                 if (CacheUpdateFailed != null)
                 {
-                    CacheUpdateFailed.Invoke(this, new CacheUpdateFailedArgs(ex));
+                    CacheUpdateFailed(this, new CacheUpdateFailedArgs(ex));
                 }                    
                 return false;
             }
@@ -60,7 +60,7 @@ namespace HobknobClientNet
             _cache = featureToggles;
             if (CacheUpdated != null)
             {
-                CacheUpdated.Invoke(this, new CacheUpdatedArgs(updates));
+                CacheUpdated(this, new CacheUpdatedArgs(updates));
             }
             return true;
         }

--- a/HobknobClientNet/FeatureToggleCache.cs
+++ b/HobknobClientNet/FeatureToggleCache.cs
@@ -50,14 +50,18 @@ namespace HobknobClientNet
             catch (Exception ex)
             {
                 if (CacheUpdateFailed != null)
+                {
                     CacheUpdateFailed.Invoke(this, new CacheUpdateFailedArgs(ex));
+                }                    
                 return false;
             }
 
             var updates = GetUpdates(_cache, featureToggles);
             _cache = featureToggles;
             if (CacheUpdated != null)
+            {
                 CacheUpdated.Invoke(this, new CacheUpdatedArgs(updates));
+            }
             return true;
         }
 

--- a/HobknobClientNet/HobknobClientFactory.cs
+++ b/HobknobClientNet/HobknobClientFactory.cs
@@ -4,12 +4,12 @@ namespace HobknobClientNet
 {
     public interface IHobknobClientFactory
     {
-        IHobknobClient Create(string etcdHost, int etcdPort, string applicationName, TimeSpan cacheUpdateInterval);
+        IHobknobClient Create(string etcdHost, int etcdPort, string applicationName, TimeSpan cacheUpdateInterval, EventHandler<CacheUpdateFailedArgs> cacheUpdateFailed);
     }
 
     public class HobknobClientFactory : IHobknobClientFactory
     {
-        public IHobknobClient Create(string etcdHost, int etcdPort, string applicationName, TimeSpan cacheUpdateInterval)
+        public IHobknobClient Create(string etcdHost, int etcdPort, string applicationName, TimeSpan cacheUpdateInterval, EventHandler<CacheUpdateFailedArgs> cacheUpdateFailed)
         {
             var etcdKeysPath = string.Format("http://{0}:{1}/v2/keys/", etcdHost, etcdPort);
 
@@ -17,6 +17,9 @@ namespace HobknobClientNet
             var featureToggleProvider = new FeatureToggleProvider(etcdClient, applicationName);
             var featureToggleCache = new FeatureToggleCache(featureToggleProvider, cacheUpdateInterval);
             var hobknobClient = new HobknobClient(featureToggleCache, applicationName);
+            if (cacheUpdateFailed == null)
+                throw new ArgumentNullException(nameof(cacheUpdateFailed));
+            featureToggleCache.CacheUpdateFailed += cacheUpdateFailed;
 
             featureToggleCache.Initialize();
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ var etcdHost = "localhost";
 var etcdPort = 4001;
 var applicationName = "radApp";
 var cacheUpdateInterval = TimeSpan.FromSeconds(180);
+EventHandler<CacheUpdateFailedArgs> cacheUpdateFailed = (o, args) => { throw args.Exception; }; 
 
-var client = new HobknobClientFactory().Create(etcdHost, etcdPort, applicationName, cacheUpdateInterval);
+var client = new HobknobClientFactory().Create(etcdHost, etcdPort, applicationName, cacheUpdateInterval, cacheUpdateFailed);
 
 var toggleValue1 = client.GetOrDefault("Feature1", true); // Feature1 is false => false
 var toggleValue2 = client.GetOrDefault("Feature2", true); // Feature2 does not exist => true
@@ -38,6 +39,7 @@ Creates a new feature toggle client.
 - `etcdPort` the port of the Etcd instance
 - `applicationName` the name of the application used to find feature toggles
 - `cacheUpdateInterval` interval for the cache update, which loads all the applications toggles into memory
+- `cacheUpdateFailed` delegate called whenever there is issue updating local hobknob cache. Must not be null for your own good.
 
 
 ### client.GetOrDefault(string featureName, bool defaultValue)
@@ -76,7 +78,7 @@ client.CacheUpdated += (sender, eventArgs) => { console.Write("Updated"); }
 
 ### client.CacheUpdateFailed
 
-An event which is raised when there is an error updating the cache
+An event which is raised when there is an error updating the cache. This is the same event as the one that is registered in Create method.
 
 ```c#
 


### PR DESCRIPTION
In current opinionated implementation creation of hobknob client would fail if there is no connectivity to hobknob host. Justification was that if you misconfigured your host you better know soon about it. What was missed is other scenario when configuration is fine, but etcd is down for any reason. If exception would be thrown then it is impossible to start application depending on hobknob without considerable addition of boilerplate code.
In this PR I suggest to keep opinionated approach, but defer to consumer actual action in case of lack of hobknob connectivity. Hence Create method now requires consumer to register onFailure delegate that will be called whenever connectivity to hobknob is down. This way we provide best practice but still allow depending application to start running and use default (hence probably safe) values for all toggles.