### PR TITLE
Add GetAll function for retrieving all toggles

### DIFF
--- a/HobknobClientNet.Tests/HobknobClientNet.Tests.csproj
+++ b/HobknobClientNet.Tests/HobknobClientNet.Tests.csproj
@@ -46,6 +46,7 @@
   <ItemGroup>
     <Compile Include="EtcdClientForTests.cs" />
     <Compile Include="Scenarios\CacheUpdates.cs" />
+    <Compile Include="Scenarios\GetAll.cs" />
     <Compile Include="Scenarios\GetOrDefault_MultiFeatureToggle.cs" />
     <Compile Include="Scenarios\GetOrDefault_SimpleFeature.cs" />
     <Compile Include="Scenarios\Initialisation.cs" />

--- a/HobknobClientNet.Tests/Scenarios/GetAll.cs
+++ b/HobknobClientNet.Tests/Scenarios/GetAll.cs
@@ -1,0 +1,31 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace HobknobClientNet.Tests.Scenarios
+{
+    internal class GetAll : TestBase
+    {
+        Dictionary<string, bool> _toggles;
+
+        [SetUp]
+        public void SetUp()
+        {
+            Set_application_name("app1");
+        }
+
+        [Test]
+        public void Get_all_toggles_for_the_given_application()
+        {
+            var _expected = new Dictionary<string, bool>()
+            {
+                { "feature1", false },
+                { "feature2", true }
+            };
+
+            Given_a_toggle("app1", "feature1", "true");
+            Given_a_toggle("app1", "feature2", "false");
+            When_I_get_all_the_toggles(out _toggles);
+            Assert.AreEqual(_toggles, _expected);
+        }
+    }
+}

--- a/HobknobClientNet.Tests/Scenarios/TestBase.cs
+++ b/HobknobClientNet.Tests/Scenarios/TestBase.cs
@@ -91,6 +91,12 @@ namespace HobknobClientNet.Tests.Scenarios
             value = HobknobClient.GetOrDefault(featureName, false);
         }
 
+        protected void When_I_get_all_the_toggles(out Dictionary<string, bool> toggles)
+        {
+            HobknobClient = new HobknobClientFactory().Create(EtcdHost, EtcdPort, _applicationName, TimeSpan.FromSeconds(1), (o, args) => { });
+            toggles = HobknobClient.GetAll();
+        }
+
         protected IHobknobClient Create_hobknob_client(EventHandler<CacheUpdateFailedArgs> errorHandler, string etcdHost = EtcdHost)
         {
             HobknobClient = new HobknobClientFactory().Create(etcdHost, EtcdPort, _applicationName, _cacheUpdateInterval, errorHandler);

--- a/HobknobClientNet/FeatureToggleCache.cs
+++ b/HobknobClientNet/FeatureToggleCache.cs
@@ -35,9 +35,13 @@ namespace HobknobClientNet
         public bool? Get(string applicationName, string featureName, string toggleName = null)
         {
             var toggleSuffix = toggleName != null ? "/" + toggleName : string.Empty;
-            var featureToggleKey = string.Format("/v1/toggles/{0}/{1}{2}", applicationName, featureName, toggleSuffix);
+            var featureToggleKey = string.Format("{0}{1}", featureName, toggleSuffix);
             bool value;
             return _cache != null && _cache.TryGetValue(featureToggleKey, out value) ? value : (bool?)null;
+        }
+        public Dictionary<string, bool> GetAll()
+        {
+            return _cache;
         }
 
         private bool UpdateCache()

--- a/HobknobClientNet/FeatureToggleProvider.cs
+++ b/HobknobClientNet/FeatureToggleProvider.cs
@@ -31,13 +31,13 @@ namespace HobknobClientNet
                     {
                         return node.Nodes
                             .Where(x => !x.Key.EndsWith("/@meta"))
-                            .Select(x => new KeyValuePair<string, bool?>(x.Key,
+                            .Select(x => new KeyValuePair<string, bool?>(ExtractFeatureToggleName(x.Key),
                                 ParseFeatureToggleValue(x.Key, x.Value)))
                             .ToArray();
                     }
                     return new[]
                     {
-                        new KeyValuePair<string, bool?>(node.Key,
+                        new KeyValuePair<string, bool?>(ExtractFeatureToggleName(node.Key),
                             ParseFeatureToggleValue(node.Key, node.Value))
                     };
                 })
@@ -59,6 +59,11 @@ namespace HobknobClientNet
                 default:
                     return null;
             }
+        }
+
+        private static string ExtractFeatureToggleName(string name)
+        {
+            return name.Split('/').Last();
         }
     }
 }

--- a/HobknobClientNet/HobknobClient.cs
+++ b/HobknobClientNet/HobknobClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace HobknobClientNet
 {
@@ -8,6 +9,7 @@ namespace HobknobClientNet
         event EventHandler<CacheUpdateFailedArgs> CacheUpdateFailed;
         bool GetOrDefault(string featureName, bool defaultValue);
         bool GetOrDefault(string featureName, string toggleName, bool defaultValue);
+        Dictionary<string, bool> GetAll();
     }
 
     public class HobknobClient : IHobknobClient
@@ -36,6 +38,11 @@ namespace HobknobClientNet
         {
             return _featureToggleCache.Get(_applicationName, featureName, toggleName)
                 .GetValueOrDefault(defaultValue);
+        }
+
+        public Dictionary<string, bool> GetAll()
+        {
+            return _featureToggleCache.GetAll();
         }
 
         private void RaiseCacheUpdatedEvent(object sender, CacheUpdatedArgs eventArgs)


### PR DESCRIPTION
The Node client has a [`getAll`](https://github.com/opentable/hobknob-client-nodejs/blob/master/src/Cache.js#L98) method that wasn't present in here.

Also, I've stripped all prefixes from features that are stored in the cache (same as the Node client).

I've been unable to run the unit tests though, so if someone could run them for me that would be stellar 😁  I've tried pointing to a local instance of `etcd` that is working correctly as I'm able to use the client perfectly fine. I've also tried running the tests against the environment created by Vagrant but am consistently getting the following error `Unable to connect to the remote server` for both cases. I'll keep plugging away and see if I can figure it out.