### PR TITLE
Use 'name/env' for environment variables.

### DIFF
--- a/HobknobClientNet/FeatureToggleProvider.cs
+++ b/HobknobClientNet/FeatureToggleProvider.cs
@@ -31,7 +31,7 @@ namespace HobknobClientNet
                     {
                         return node.Nodes
                             .Where(x => !x.Key.EndsWith("/@meta"))
-                            .Select(x => new KeyValuePair<string, bool?>(ExtractFeatureToggleName(x.Key),
+                            .Select(x => new KeyValuePair<string, bool?>(ExtractFeatureToggleName(x.Key, true),
                                 ParseFeatureToggleValue(x.Key, x.Value)))
                             .ToArray();
                     }
@@ -61,9 +61,11 @@ namespace HobknobClientNet
             }
         }
 
-        private static string ExtractFeatureToggleName(string name)
+        private static string ExtractFeatureToggleName(string name, bool isDir = false)
         {
-            return name.Split('/').Last();
+            var tokens = name.Split('/').ToList();
+
+            return isDir ? string.Join(",", tokens.Skip(tokens.Count - 2)) : tokens.Last();
         }
     }
 }

--- a/HobknobClientNet/FeatureToggleProvider.cs
+++ b/HobknobClientNet/FeatureToggleProvider.cs
@@ -65,7 +65,7 @@ namespace HobknobClientNet
         {
             var tokens = name.Split('/').ToList();
 
-            return isDir ? string.Join(",", tokens.Skip(tokens.Count - 2)) : tokens.Last();
+            return isDir ? string.Join("/", tokens.Skip(tokens.Count - 2)) : tokens.Last();
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hobknob-client-net",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A .net client library for Hobknob",
   "company": "OpenTable",
   "main": "Gruntfile.js",


### PR DESCRIPTION
This fixes the error received when multiple enviroment toggles are present. The environment toggle name is now in the format 'toggleName/env' as to not receive a duplicate key when trying to add them in the cache which is a dictionary.